### PR TITLE
Improve the map view on pages loading

### DIFF
--- a/js/map-landing.js
+++ b/js/map-landing.js
@@ -108,9 +108,16 @@ $.getJSON('data/region.geojson',function(data){
         }
   	});
 
-    map.fitBounds(regionLayer.getBounds());
-	regionLayer.addTo(map);
     regiondata = data.features;
+
+    var sortedBydate = [];
+    for (var i = 0; i < regiondata.length; i++){
+        sortedBydate.push({index:i, date:new Date(regiondata[i].properties.DATE)});
+    }
+    sortedBydate.sort((a, b) => b.date - a.date);
+    map.setView([regiondata[sortedBydate[0].index].geometry.coordinates[1],regiondata[sortedBydate[0].index].geometry.coordinates[0]],5);
+    regionLayer.addTo(map);
+
 });
 
 // function that reset original icon to the layers selectLayer and spotLayer

--- a/js/map.js
+++ b/js/map.js
@@ -454,7 +454,12 @@ $.getJSON('data/region.geojson',function(data){
             map.setView([getUrlParameters(window.location.href).lat,getUrlParameters(window.location.href).lng], getUrlParameters(window.location.href).zoom);
         }
         else{
-    	   map.fitBounds(regionLayer.getBounds());
+            var sortedBydate = [];
+            for (var i = 0; i < regiondata.length; i++){
+                sortedBydate.push({index:i, date:new Date(regiondata[i].properties.DATE)});
+            }
+            sortedBydate.sort((a, b) => b.date - a.date);
+            map.setView([regiondata[sortedBydate[0].index].geometry.coordinates[1],regiondata[sortedBydate[0].index].geometry.coordinates[0]],5);
         }
     	regionLayer.addTo(map);
 
@@ -1091,7 +1096,15 @@ $(document).ready(function(){
                 }
                 regionLayer.addTo(map);
                 selectLayerZoom = undefined;
-                map.fitBounds(regionLayer.getBounds());
+
+                var sortedBydate = [];
+                for (var i = 0; i < regiondata.length; i++){
+                    sortedBydate.push({index:i, date:new Date(regiondata[i].properties.DATE)});
+                }
+                sortedBydate.sort((a, b) => b.date - a.date);
+                map.setView([regiondata[sortedBydate[0].index].geometry.coordinates[1],regiondata[sortedBydate[0].index].geometry.coordinates[0]],5);
+                regionLayer.addTo(map);
+
                 updateUrlParameters(window.location.href,undefined,undefined,map.getCenter().lat,map.getCenter().lng,map.getZoom());
             }
             // Case when there are 1 selected spot


### PR DESCRIPTION
Set the center of the map to the last region with a zoom of 5 instead of fitting the map view to all regions for these 3 cases

1. On the load of the landing page's map
2. On the load of the webmapping page when no other information is given (e.g. from url)
3. When the user hits the back arrow to return to the region layer view

On small screens (mobile devices), trying to fit the map view to all regions makes the regions icons to overlap themselves. 